### PR TITLE
Simplify sphere intersection test

### DIFF
--- a/src/shape/sphere.rs
+++ b/src/shape/sphere.rs
@@ -10,26 +10,28 @@ pub struct Sphere;
 #[allow(clippy::many_single_char_names)]
 impl Shape for Sphere {
     fn intersect(&self, ray: &Ray, t_min: f64, record: &mut HitRecord) -> bool {
-        // Translated directly from the GLOO source code, assuming radius = 1
+        // Based on the GLOO source code, assuming radius = 1
         let a = glm::length2(&ray.dir);
-        let b = 2.0 * glm::dot(&ray.dir, &ray.origin);
+        let b = glm::dot(&ray.dir, &ray.origin);
         let c = glm::length2(&ray.origin) - 1.0;
 
-        let d = b * b - 4.0 * a * c;
+        let d = b * b - a * c;
         if d.is_sign_negative() {
             return false;
         }
 
         let d = d.sqrt();
-        let t_plus = (-b + d) / (2.0 * a);
-        let t_minus = (-b - d) / (2.0 * a);
-        let t = if t_minus < t_min {
-            if t_plus < t_min {
-                return false;
+        let t = {
+            let t_minus = (-b - d) / a;
+            if t_minus < t_min {
+                let t_plus = (-b + d) / a;
+                if t_plus < t_min {
+                    return false;
+                }
+                t_plus
+            } else {
+                t_minus
             }
-            t_plus
-        } else {
-            t_minus
         };
 
         if t < record.time {


### PR DESCRIPTION
Hey, really amazing work what you did! Though, one little thing I noticed while looking through the code was that the sphere-ray intersection could be simplified.

Since `b` is always multiplied by 2, it can actually be omitted if the multiplication of `d` by 4 is removed, as well as the `2.0` factor in division of `t_plus` and `t_minus`.

I linked a more thorough explanation of this below, from Peter Shirley's RTIOW. Although, you may want to keep it the way it is as it might be clearer 🙂

Reference: https://raytracing.github.io/books/RayTracingInOneWeekend.html#surfacenormalsandmultipleobjects/simplifyingtheray-sphereintersectioncode